### PR TITLE
Move message_callback to device vs PLM

### DIFF
--- a/insteonplm/__init__.py
+++ b/insteonplm/__init__.py
@@ -30,7 +30,8 @@ class Connection:
     @asyncio.coroutine
     def create(cls, device='/dev/ttyUSB0', ipaddress=None,
                username=None, password=None, port=25010,
-               auto_reconnect=True, loop=None, workdir=None):
+               auto_reconnect=True, loop=None, workdir=None,
+               poll_devices=True):
         """Initiate a connection to a specific device.
 
         Here is where we supply the device and callback callables we
@@ -83,7 +84,8 @@ class Connection:
         conn.protocol = protocol_class(
             connection_lost_callback=connection_lost,
             loop=conn._loop,
-            workdir=workdir)
+            workdir=workdir,
+            poll_devices=poll_devices)
 
         yield from conn._reconnect()
 

--- a/insteonplm/devices/dimmableLightingControl.py
+++ b/insteonplm/devices/dimmableLightingControl.py
@@ -28,7 +28,7 @@ class DimmableLightingControl(Device):
 
         self._stateList[0x01] = DimmableSwitch(
             self._address, "lightOnLevel", 0x01, self._send_msg,
-            self._plm.message_callbacks, 0x00)
+            self._message_callbacks, 0x00)
 
 
 class DimmableLightingControl_2475F(DimmableLightingControl):
@@ -66,7 +66,7 @@ class DimmableLightingControl_2475F(DimmableLightingControl):
 
         self._stateList[0x01] = DimmableSwitch(
             self._address, "lightOnLevel", 0x01, self._send_msg,
-            self._plm.message_callbacks, 0x00)
+            self._message_callbacks, 0x00)
         self._stateList[0x02] = DimmableSwitch_Fan(
             self._address, "fanOnLevel", 0x02, self._send_msg,
-            self._plm.message_callbacks, 0x00)
+            self._message_callbacks, 0x00)

--- a/insteonplm/devices/securityHealthSafety.py
+++ b/insteonplm/devices/securityHealthSafety.py
@@ -34,7 +34,7 @@ class SecurityHealthSafety(Device):
 
         self._stateList[0x01] = VariableSensor(
             self._address, "generalSensor", 0x01, self._send_msg,
-            self._plm.message_callbacks, 0x00)
+            self._message_callbacks, 0x00)
 
 
 class SecurityHealthSafety_2421(Device):
@@ -63,7 +63,7 @@ class SecurityHealthSafety_2421(Device):
 
         self._stateList[0x01] = OnOffSensor(
             self._address, "openClosedSensor", 0x01, self._send_msg,
-            self._plm.message_callbacks, 0x00)
+            self._message_callbacks, 0x00)
 
 
 class SecurityHealthSafety_2842_222(Device):
@@ -92,7 +92,7 @@ class SecurityHealthSafety_2842_222(Device):
 
         self._stateList[0x01] = OnOffSensor(
             self._address, "motionSensor", 0x01, self._send_msg,
-            self._plm.message_callbacks, 0x00)
+            self._message_callbacks, 0x00)
 
 
 class SecurityHealthSafety_2845_222(Device):
@@ -121,7 +121,7 @@ class SecurityHealthSafety_2845_222(Device):
 
         self._stateList[0x01] = OnOffSensor(
             self._address, "doorSensor", 0x01, self._send_msg,
-            self._plm.message_callbacks, 0x00)
+            self._message_callbacks, 0x00)
 
 
 class SecurityHealthSafety_2852_222(Device):
@@ -150,17 +150,17 @@ class SecurityHealthSafety_2852_222(Device):
 
         self._stateList[0x01] = LeakSensorDryWet(
             self._address, "dryLeakSensor", 0x01, self._send_msg,
-            self._plm.message_callbacks,
+            self._message_callbacks,
             defaultvalue=0x01,
             dry_wet=LeakSensorState.DRY)
         self._stateList[0x02] = LeakSensorDryWet(
             self._address, "wetLeakSensor", 0x02, self._send_msg,
-            self._plm.message_callbacks,
+            self._message_callbacks,
             defaultvalue=0x00,
             dry_wet=LeakSensorState.WET)
         self._stateList[0x04] = LeakSensorHeartbeat(
             self._address, "heartbeatLeakSensor", 0x04, self._send_msg,
-            self._plm.message_callbacks,
+            self._message_callbacks,
             defaultvalue=0x11)
         
         self._stateList[0x01].register_dry_wet_callback(
@@ -213,4 +213,4 @@ class SecurityHealthSafety_2982_222(Device):
 
         self._stateList[0x01] = SmokeCO2Sensor(
             self._address, "smokeCO2Sensor", 0x01, self._send_msg,
-            self._plm.message_callbacks, 0x00)
+            self._message_callbacks, 0x00)

--- a/insteonplm/devices/sensorsActuators.py
+++ b/insteonplm/devices/sensorsActuators.py
@@ -38,7 +38,7 @@ class SensorsActuators(Device):
 
         self._stateList[0x01] = OpenClosedRelay(
             self._address, "openClosedRelay", 0x01, self._send_msg,
-            self._plm.message_callbacks, 0x00)
+            self._message_callbacks, 0x00)
 
 
 class SensorsActuators_2450(SensorsActuators):
@@ -75,7 +75,7 @@ class SensorsActuators_2450(SensorsActuators):
 
         self._stateList[0x01] = OpenClosedRelay(
             self._address, "openClosedRelay", 0x01, self._send_msg,
-            self._plm.message_callbacks, 0x00)
+            self._message_callbacks, 0x00)
         self._stateList[0x02] = IoLincSensor(
             self._address, "openClosedSensor", 0x02, self._send_msg,
-            self._plm.message_callbacks, 0x00)
+            self._message_callbacks, 0x00)

--- a/insteonplm/devices/switchedLightingControl.py
+++ b/insteonplm/devices/switchedLightingControl.py
@@ -29,7 +29,7 @@ class SwitchedLightingControl(Device):
 
         self._stateList[0x01] = OnOffSwitch(
             self._address, "lightOnOff", 0x01, self._send_msg,
-            self._plm.message_callbacks, 0x00)
+            self._message_callbacks, 0x00)
 
 
 class SwitchedLightingControl_2663_222(Device):
@@ -60,7 +60,7 @@ class SwitchedLightingControl_2663_222(Device):
 
         self._stateList[0x01] = OnOffSwitch_OutletTop(
             self._address, "outletTopOnOff", 0x01, self._send_msg,
-            self._plm.message_callbacks, 0x00)
+            self._message_callbacks, 0x00)
         self._stateList[0x02] = OnOffSwitch_OutletBottom(
             self._address, "outletBottomOnOff", 0x02, self._send_msg,
-            self._plm.message_callbacks, 0x00)
+            self._message_callbacks, 0x00)

--- a/insteonplm/tools.py
+++ b/insteonplm/tools.py
@@ -1,173 +1,539 @@
 """Provides a raw console to test module and demonstrate usage."""
 import argparse
 import asyncio
+from asynccmd import Cmd
 import logging
 
 import insteonplm
+from insteonplm.address import Address
+from insteonplm.devices import Device
 
-__all__ = ('console', 'monitor')
+__all__ = ('Tools', 'monitor', 'all_linking')
+
+_LOGGING = logging.getLogger()
 
 
-@asyncio.coroutine
-def console(loop, log, devicelist):
+class Tools(Cmd):
+    def __init__(self, loop, args=None):
+        super().__init__(mode="Reader")
+        # common variables
+        self.loop = loop
+        self.plm = None
+        self.device = args.device
+        self.workdir = args.workdir
+
+        # all-link variables
+        self.address = None
+        self.linkcode = None
+        self.group = None
+        self.wait_time = 10
+
+        if args:
+            if args.verbose:
+                level = logging.DEBUG
+            else:
+                level = logging.INFO
+
+            if hasattr(args, 'address'):
+                self.address = args.address
+            if hasattr(args, 'group'):
+                self.group = int(args.group)
+            if hasattr(args, 'linkcode'):
+                self.linkcode = int(args.linkcode)
+            if hasattr(args, 'wait'):
+                self.wait_time = int(args.wait)
+
+        logging.basicConfig(level=level)
+
+    @asyncio.coroutine
+    def connect(self, poll_devices):
+        _LOGGING.info('Connecting to Insteon PLM at %s', self.device)
+        workdir = None if self.workdir == '' else self.workdir
+        conn = yield from insteonplm.Connection.create(
+            device=self.device, loop=self.loop,
+            poll_devices=poll_devices,
+             workdir=workdir)
+        print('Setting up new device callback')
+        conn.protocol.add_device_callback(self.async_new_device_callback)
+        print('Setting up ALDB loaded callback')
+        conn.protocol.add_all_link_done_callback(
+            self.async_aldb_loaded_callback)
+        self.plm = conn.protocol
+
+    def async_new_device_callback(self, device):
+        """Log that our new device callback worked."""
+        _LOGGING.info('New Device: %s %02x %02x %s, %s',
+                      device.id, device.cat, device.subcat,
+                      device.description, device.model)
+        'New Device: %s %02x %02x %s, %s'.format(
+                      device.id, device.cat, device.subcat,
+                      device.description, device.model)
+        for state in device.states:
+            device.states[state].register_updates(
+                self.async_state_change_callback)
+
+    def async_state_change_callback(self, id, state, value):
+        _LOGGING.info('Device %s state %s value is changed to %02x',
+                      id, state, value)
+        'Device %s state %s value is changed to %02x'.format(
+                      id, state, value)
+
+    def async_aldb_loaded_callback(self):
+        print('ALDB Loaded')
+
+    @asyncio.coroutine
+    def all_link_console(self,):
+        yield from self.do_connect(False)
+        self.plm.register_devices_loaded_callback(self.schedule_all_link)
+
+    def schedule_all_link(self):
+        asyncio.ensure_future(self.do_all_link())
+        yield from asyncio.sleep(.01, loop=self.loop)
+
+    @asyncio.coroutine
+    def all_link(self, linkcode, group, address=None):
+        _LOGGING.info('Starting the All-Linking process')
+        if self.address != '':
+            linkdevice = Device.create(self.plm, self.address, None, None)
+            retries = 0
+            while self.plm.devices[self.address] is None and retries < 3:
+                _LOGGING.info('Attempting to link to device %s. '
+                              'Waiting %d seconds.',
+                              self.address, self.wait_time)
+                self.plm.start_all_linking(self.linkcode, self.group)
+                linkdevice.enter_linking_mode(group=self.group)
+                retries = retries + 1
+                yield from asyncio.sleep(self.wait_time, loop=self.loop)
+        else:
+            _LOGGING.info('Starting All-Linking on PLM. '
+                          'Waiting for button press')
+            self.plm.start_all_linking(self.linkcode, self.group)
+            yield from asyncio.sleep(self.wait_time, loop=self.loop)
+
+        _LOGGING.info('%d devices added to the All-Link Database',
+                      len(self.plm.devices))
+        yield from asyncio.sleep(.1, loop=self.loop)
+        self.loop.stop()
+
+    @asyncio.coroutine
+    def list_devices(self):
+        """List devices in the ALDB."""
+        for addr in self.plm.devices:
+            device = self.plm.devices[addr]
+            _LOGGING.info('Device: %s %s [%s]',
+                          device.address.human,
+                          device.description,
+                          device.model)
+
+    @asyncio.coroutine
+    def on_off_test(self, addr, group):
+        """Test the on/off method of a device.
+
+        Usage:
+            on_off_test address [group]
+        Arguments:
+            address: Required - INSTEON address of the device
+            group: Optional - All-Link group number. Defaults to 1
+        """
+        if addr:
+            device = self.plm.devices[addr]
+
+        if device:
+            state = device.states[group]
+
+        if state:
+            if hasattr(state, 'on') and hasattr(state, 'off'):
+                _LOGGING.info('Send on request')
+                _LOGGING.info('----------------------')
+                device.states[group].on()
+                yield from asyncio.sleep(2, loop=self.loop)
+
+                _LOGGING.info('Send off request')
+                _LOGGING.info('----------------------')
+                device.states[group].off()
+                yield from asyncio.sleep(2, loop=self.loop)
+
+                _LOGGING.info('Send on request')
+                _LOGGING.info('----------------------')
+                device.states[group].on()
+                yield from asyncio.sleep(2, loop=self.loop)
+
+                _LOGGING.info('Send off request')
+                _LOGGING.info('----------------------')
+                device.states[group].off()
+                yield from asyncio.sleep(2, loop=self.loop)
+            else:
+                print('Device %s with state %d is not an on/off device.')
+
+        else:
+            print('Could not find device %s with state %d',
+                  addr, group)
+
+    @asyncio.coroutine
+    def do_test4(self):
+        for addr in self.plm.devices:
+            device = self.plm.devices[addr]
+            device.get_engine_version()
+            yield from asyncio.sleep(.1, loop=self.loop)
+            if device.engine_version is not None:
+                _LOGGING.info('Addres: %s  DB Version: %s',
+                                device.address, device.engine_version)
+            else:
+                _LOGGING.info('Addres: %s did not respond to engine '
+                                'version request.')
+
+    @asyncio.coroutine
+    def get_device_aldb(self, addr):
+        """Diplay the All-Link database for a device."""
+        device = self.plm.devices[addr]
+        if device:
+            if not device.aldb:
+                device.read_aldb()
+            yield from asyncio.sleep(10, loop=self.loop)
+            _LOGGING.info('Found %d records', len(device.aldb))
+            if (not device.aldb or
+                not device.aldb[-1].control_flags.is_high_water_mark):
+                _LOGGING.info('Read failed.')
+                device.aldb.clear()
+            else:
+                for record in device.aldb:
+                    _LOGGING.info('ALDB record: %s', str(record))
+        else:
+            _LOGGING.info('Device not found.')
+
+    @asyncio.coroutine
+    def load_device_aldb(self, addr):
+        """Read the device ALDB."""
+        device = self.plm.devices[addr]
+        if device:
+            device.aldb.clear()
+            device.read_aldb()
+            yield from asyncio.sleep(10, loop=self.loop)
+            _LOGGING.info('Found %d records', len(device.aldb))
+            if (not device.aldb or
+                not device.aldb[-1].control_flags.is_high_water_mark):
+                _LOGGING.info('Read failed.')
+                device.aldb.clear()
+            else:
+                for record in device.aldb:
+                    _LOGGING.info('ALDB record: %s', str(record))
+
+    @asyncio.coroutine
+    def get_device_callbacks(self, addr):
+        """List the callbacks for a device."""
+        device_addr = Address(addr)
+        for msg in self.plm.message_callbacks:
+            if hasattr(msg, 'address'):
+                if msg.address == device_addr:
+                    _LOGGING.info('-------------- CALLBACK ---------------')
+                    _LOGGING.info(msg)
+                    _LOGGING.info(self.plm.message_callbacks[msg])
+
+
+class Commander(Cmd):
+    """Command object to manage itneractive sessions."""
+
+    def __init__(self, loop, args):
+        self.prompt = "insteonplm: "
+        self.intro = ('INSTEON PLM interactive command processor. '
+                      'Type `help` for a list of commands.')
+        self.loop = loop
+        self.tools = Tools(loop, args)
+
+    def start_interactive(self):
+        """Start the interactive command loop."""
+        super().cmdloop(self.loop)
+
+    def do_connect(self, args):
+        """Connect to the PLM device.
+        
+        Usage:
+            connect
+        Arguments:
+        """
+        self.loop.create_task(self.tools.connect(False))
+
+    def do_running_tasks(self, arg):
+        """List running tasks.
+
+        Usage:
+            running_tasks
+        Arguments:
+        """
+        for task in asyncio.Task.all_tasks(loop=self.loop):
+            print(task)
+
+    def do_on_off_test(self, args):
+        """Test the on/off method of a device.
+
+        Usage:
+            on_off_test address [group]
+        Arguments:
+            address: Required - INSTEON address of the device
+            group: Optional - All-Link group number. Defaults to 1
+        """
+        params = args.split()
+        addr = None
+        group = None
+
+        try:
+            addr = params[0]
+        except IndexError:
+            print('Device address required.')
+            print('Usage: on_off_test address [group]')
+        try:
+            group_str = params[2]
+            try:
+                group = int(group_str)
+            except ValueError:
+                group = 1
+        except IndexError:
+            group = 1
+
+        if addr:
+            self.loop.create_task(self.tools.on_off_test(addr, group))
+
+    def do_list_devices(self, args):
+        """List devices loaded in the PLM.
+
+        Usage:
+            list_devices
+        Arguments:
+        """
+        self.loop.create_task(self.tools.list_devices())
+
+    def do_start_all_linking(self, args):
+        """Place the PLM in All-Link mode.
+
+        Usage:
+            start_all_linking [linkcode [group]]
+        Arguments:
+            linkcode: 0 - PLM is responder
+                      1 - PLM is controller
+                      3 - PLM is controller or responder
+                      Default 1
+            group: All-Link group number (0 - 255). Default 0.
+        """
+        linkcode = 1
+        group = 0
+        params = args.split()
+        if params:
+            try:
+                linkcode = params[0]
+            except IndexError:
+                linkcode = 1
+            try:
+                group = params[1]
+            except IndexError:
+                group = 0
+        if linkcode in [0, 1, 3] and group >= 0 and group <= 255:
+            self.loop.task(self.tools.start_all_linking(linkcode, group))
+        else:
+            _LOGGING('Could not start')
+
+    def do_get_device_aldb(self, args):
+        """Load the All-Link database for a devicedevice.
+
+        Usage:
+            get_device_aldb address
+        Arguments:
+            address: Required - INSTEON address of the device
+        """
+        params = args.split()
+        addr = None
+        group = None
+
+        try:
+            addr = params[0]
+        except IndexError:
+            print('Device address required.')
+            print('Usage: device_aldb address')
+
+        if addr:
+            self.loop.create_task(self.tools.get_device_aldb(addr))
+
+    def do_load_device_aldb(self, args):
+        """Load the All-Link database for a devicedevice.
+
+        Usage:
+            load_device_aldb address
+        Arguments:
+            address: Required - INSTEON address of the device
+        """
+        params = args.split()
+        addr = None
+        group = None
+
+        try:
+            addr = params[0]
+        except IndexError:
+            print('Device address required.')
+            print('Usage: load_device_aldb address')
+
+        if addr:
+            self.loop.create_task(self.tools.load_device_aldb(addr))
+
+    def do_set_log_level(self, arg):
+        """Set the log level.
+
+        Usage:
+            set_log_level i|v
+        Parameters:
+            log_level: i - info
+                       v - verbose
+    """
+        if arg in ['i', 'v']:
+            if arg == 'i':
+                _LOGGING.setLevel(logging.INFO)
+            else:
+                _LOGGING.setLevel(logging.DEBUG)
+        else:
+            print('Log level incorrect.')
+            self.do_help('set_log_level')
+
+    def do_help(self, arg):
+        """Help command.
+
+        Usage:
+            help [command]
+        Parameters:
+            command: Optional - command name to display detailed help
+        """
+        cmds = arg.split()
+
+        if cmds:
+            func = getattr(self, 'do_{}'.format(cmds[0]))
+            if func:
+                print(func.__doc__)
+            else:
+                print('Command ', cmds[0], ' not found.')
+        else:
+            print("Available command list: ")
+            for curr_cmd in dir(self.__class__):
+                if curr_cmd.startswith("do_") and not curr_cmd == 'do_test':
+                    print(" - ", curr_cmd[3:])
+            print("For help with a command type `help command`")
+
+    def do_get_device_callbacks(self, args):
+        """List the callbacks for a device.
+
+        Usage:
+            load_device_aldb address
+        Arguments:
+            address: Required - INSTEON address of the device
+        """
+        params = args.split()
+        addr = None
+        group = None
+
+        try:
+            addr = params[0]
+        except IndexError:
+            print('Device address required.')
+            print('Usage: load_device_aldb address')
+
+        if addr:
+            self.loop.create_task(self.tools.get_device_callbacks(addr))
+
+    def _emptyline(self, line):
+        """Handler for empty line if entered.
+
+        Override default behavior. Do nothing instead of repeating
+        the last command.
+        """
+        pass
+
+
+def monitor():
     """Connect to receiver and show events as they occur.
 
-    Pulls the following arguments from the command line (not method arguments):
+    Pulls the following arguments from the command line:
 
     :param device:
         Unix device where the PLM is attached
+    :param address:
+        Insteon address of the device to link with
+    :param group:
+        Insteon group for the link
+    :param: linkcode
+        Link direction: 0 - PLM is responder
+                        1 - PLM is controller
+                        3 - IM is responder or controller'
     :param verbose:
         Show debug logging.
     """
-    parser = argparse.ArgumentParser(description=console.__doc__)
-    parser.add_argument('--device', default='/dev/ttyUSB0', help='Device')
-    parser.add_argument('--verbose', '-v', action='count')
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--device', default='/dev/ttyUSB0',
+                        help='Path to PLM device')
+    parser.add_argument('--verbose', '-v', action='count',
+                        help='Set logging level to verbose')
+    parser.add_argument('-workdir', default='',
+                        help='Working directory for reading and saving '
+                        'device information.')
 
     args = parser.parse_args()
-
-    if args.verbose:
-        level = logging.DEBUG
-    else:
-        level = logging.INFO
-
-    logging.basicConfig(level=level)
-
-    device = args.device
-
-    log.info('Connecting to Insteon PLM at %s', device)
-
-    conn = yield from insteonplm.Connection.create(device=device, loop=loop,
-                                                   userdefined=devicelist)
-
-    def async_insteonplm_add_device_callback(device):
-        """Log that our new device callback worked."""
-        log.warn('New Device: %s %02x %02x %s, %s', device.id, device.cat,
-                 device.subcat, device.description, device.model)
-        for state in device.states:
-            device.states[state].register_updates(async_state_change_callback)
-
-    def async_state_change_callback(id, state, value):
-        log.info('Device %s state %s value is changed to %02x',
-                 id, state, value)
-
-    conn.protocol.add_device_callback(async_insteonplm_add_device_callback)
-
-    plm = conn.protocol
-
-    yield from asyncio.sleep(150, loop=loop)
-
-    if False:
-        device = plm.devices['14627a']
-        device.states[0x01].off()
-
-        log.debug('Sent office light off request')
-        log.debug('----------------------')
-        yield from asyncio.sleep(5, loop=loop)
-
-        device.states[0x01].on()
-        log.debug('Sent office light on request')
-        log.debug('----------------------')
-
-    if False:
-        for key in plm.devices:
-            log.debug('Address: %s', key)
-        yield from asyncio.sleep(5, loop=loop)
-
-    if False:
-        # Test Top Outlet
-        device = plm.devices['4189cf']
-        device.states[0x01].off()
-
-        log.debug('Sent top outlet off request')
-        log.debug('----------------------')
-        yield from asyncio.sleep(5, loop=loop)
-
-        device.states[0x01].on()
-        log.debug('Sent top outlet on request')
-        log.debug('----------------------')
-
-        # Test Bottom Outlet
-        device.states[0x02].off()
-
-        log.debug('Sent bottom outlet off request')
-        log.debug('----------------------')
-        yield from asyncio.sleep(5, loop=loop)
-
-        device.states[0x02].on()
-        log.debug('Sent bottom outlet on request')
-        log.debug('----------------------')
-
-    if False:
-        # Test Status Request message
-        state1 = plm.devices['4189cf'].states[0x01]
-        state2 = plm.devices['4189cf'].states[0x02]
-
-        log.debug('Setting top outlet off and bottom outlet on')
-        log.debug('----------------------')
-        state1.off()
-        state2.on()
-        yield from asyncio.sleep(5, loop=loop)
-
-        log.debug('Sent top outlet status request')
-        log.debug('----------------------')
-        state1.async_refresh_state()
-        yield from asyncio.sleep(5, loop=loop)
-
-        log.debug('Sent top and bottom outlet status request')
-        log.debug('----------------------')
-        state2.async_refresh_state()
-        yield from asyncio.sleep(5, loop=loop)
-
-        log.debug('Turn Bottom outlet off')
-        log.debug('----------------------')
-        state2.off()
-        yield from asyncio.sleep(5, loop=loop)
-
-        log.debug('Sent light status request')
-        log.debug('----------------------')
-        state2.async_refresh_state()
-
-        yield from asyncio.sleep(5, loop=loop)
-
-        log.debug('Turn Bottom outlet on')
-        log.debug('----------------------')
-        state2.on()
-
-    if True:
-        device = plm.devices['462f24']
-        device.read_aldb()
-        yield from asyncio.sleep(30, loop=loop)
-        log.info('-----------------------------------')
-        for rec in device.aldb:
-            log.info('ALDB Record: %s', rec)
-
-    if True:
-        for addr in plm.devices:
-            device = plm.devices[addr]
-            device.product_data_request()
-
-    if True:
-        log.info('--------------------------')
-        log.info('Starting All-Linking')
-        plm.start_all_linking(linkcode=1, group=0)
-
-def monitor():
-    """Wrapper to call console with a loop."""
-    devicelist = (
-        {
-            "address": "3c4fc5",
-            "cat": 0x05,
-            "subcat": 0x0b,
-            "firmware": 0x00
-        },
-        {
-            "address": "43af9b",
-            "cat": 0x02,
-            "subcat": 0x1a,
-            "firmware": 0x00
-        }
-    )
-    log = logging.getLogger(__name__)
     loop = asyncio.get_event_loop()
-    asyncio.async(console(loop, log, devicelist))
+    monTool = Tools(loop, args)
+    asyncio.ensure_future(monTool.do_connect())
     loop.run_forever()
+    loop.close()
+
+
+def all_linking():
+    """Wrapper to call console with a loop."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--device', default='/dev/ttyUSB0',
+                        help='Path to PLM device')
+    parser.add_argument('-v', '--verbose', action='count',
+                        help='Set logging level to verbose')
+    parser.add_argument('-a', '--address', default='',
+                        help='Device to link to in the format of 1a2b3c. '
+                        '(only works for i2 devices)')
+    parser.add_argument('-g', '--group', default=1,
+                        help='All-Link group number to link to')
+    parser.add_argument('-l', '--linkcode', default=3,
+                        help='Control flags: '
+                        '0 - PLM is responder  '
+                        '1 - PLM is controller '
+                        '3 - IM is responder or controller')
+    parser.add_argument('-w', '--wait', default=10,
+                        help='Wait time for how long the PLM waits for a '
+                        'device to respond to the All-Link request.')
+    args = parser.parse_args()
+
+    loop = asyncio.get_event_loop()
+    linkTool = Tools(loop, args)
+    asyncio.ensure_future(linkTool.all_link_console(args))
+    loop.run_forever()
+    loop.close()
+
+
+def interactive():
+    """Wrapper for an interactive session for manual commands to be entered."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--device', default='/dev/ttyUSB0',
+                        help='Path to PLM device')
+    parser.add_argument('-v', '--verbose', action='count',
+                        help='Set logging level to verbose')
+    parser.add_argument('-workdir', default='',
+                        help='Working directory for reading and saving '
+                        'device information.')
+    args = parser.parse_args()
+
+    loop = asyncio.get_event_loop()
+    cmd = Commander(loop, args)
+    cmd.start_interactive()
+    try:
+        loop.run_forever()
+    except KeyboardInterrupt:
+        loop.stop()
+        pending = asyncio.Task.all_tasks(loop=loop)
+        for task in pending:
+            task.cancel()
+            try:
+                loop.run_until_complete(task)
+            except asyncio.CancelledError:
+                pass
+        loop.close()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pyserial==3.2.0
 pyserial-asyncio
 async_timeout
+asynccmd

--- a/setup.py
+++ b/setup.py
@@ -36,9 +36,12 @@ setup(
     install_requires=[
         'pyserial==3.2.0',
         'pyserial-asyncio',
-        'async_timeout'
+        'async_timeout',
+        'asynccmd'
     ],
     entry_points={
-        'console_scripts': ['insteonplm_monitor = insteonplm.tools:monitor', ]
+        'console_scripts': [ 'insteonplm_monitor = insteonplm.tools:monitor',
+                             'insteonplm_link = insteonplm.tools:all_linking',
+                             'insteonplm_interactive = insteonplm.tools:interactive' ]
     }
 )

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,3 @@
 """Tests for insteonplm module."""
+import logging
+_LOGGER = logging.getLogger()

--- a/tests/mockPLM.py
+++ b/tests/mockPLM.py
@@ -1,5 +1,7 @@
 """Mock PLM class for testing devices."""
+import logging
 from insteonplm.messagecallback import MessageCallback
+from insteonplm.aldb import ALDB
 
 
 class MockPLM(object):
@@ -7,9 +9,11 @@ class MockPLM(object):
 
     def __init__(self, loop=None):
         """Initialize the MockPLM class."""
+        self.log = logging.getLogger()
         self.sentmessage = ''
         self._message_callbacks = MessageCallback()
         self.loop = loop
+        self.devices = ALDB()
 
     @property
     def message_callbacks(self):
@@ -22,6 +26,13 @@ class MockPLM(object):
 
     def message_received(self, msg):
         """Fake a message being received by the PLM."""
+        if hasattr(msg, 'address'):
+            device = self.devices[msg.address.hex]
+            if device:
+                device.receive_message(msg)
+            else:
+                self.log.info('Received message for unknown device %s',
+                                msg.address)
         for callback in (
                 self._message_callbacks.get_callbacks_from_message(msg)):
             callback(msg)

--- a/tests/test_dimmableLightingControl.py
+++ b/tests/test_dimmableLightingControl.py
@@ -40,6 +40,8 @@ def test_dimmableLightingControl():
         assert device.model == model
         assert device.id == address
 
+        plm.devices[device.address.hex] = device
+
         callbacks = MockCallbacks()
         device.states[0x01].register_updates(callbacks.callbackmethod1)
 
@@ -117,6 +119,8 @@ def test_dimmableLightingControl_manual_changes():
         assert device.model == model
         assert device.id == address
 
+        plm.devices[device.address.hex] = device
+
         callbacks = MockCallbacks()
         device.states[0x01].register_updates(callbacks.callbackmethod1)
 
@@ -163,6 +167,7 @@ def test_dimmableLightingControl_status():
         assert device.description == description
         assert device.model == model
         assert device.id == address
+        plm.devices[device.address.hex] = device
 
         callbacks = MockCallbacks()
         device.states[0x01].register_updates(callbacks.callbackmethod1)
@@ -220,7 +225,9 @@ def test_switchedLightingControl_2475F():
 
         device = DimmableLightingControl_2475F.create(
             mockPLM, address, cat, subcat, product_key, description, model)
-
+        
+        mockPLM.devices[device.address.hex] = device
+        
         assert device.states[0x01].name == 'lightOnLevel'
         assert device.states[0x02].name == 'fanOnLevel'
 
@@ -278,7 +285,8 @@ def test_dimmableLightingControl_2475F_status():
 
         device = DimmableLightingControl_2475F(plm, address, cat, subcat,
                                                product_key, description, model)
-
+        
+        plm.devices[device.address.hex] = device
         callbacks = MockCallbacks()
         device.states[0x02].register_updates(callbacks.callbackmethod1)
 

--- a/tests/test_plm.py
+++ b/tests/test_plm.py
@@ -78,7 +78,7 @@ def do_plm(loop, log, devicelist):
 
     def async_insteonplm_light_callback(device):
         """Log that our new device callback worked."""
-        log.info('New Device: %s %02x %02x %s, %s', device.id, device.cat,
+        log.warn('New Device: %s %02x %02x %s, %s', device.id, device.cat,
                  device.subcat, device.description, device.model)
 
     def async_light_on_level_callback(device_id, state, value):
@@ -126,11 +126,12 @@ def do_plm(loop, log, devicelist):
     plm.data_received(msg.bytes)
     yield from asyncio.sleep(.1)
     for addr in plm.devices:
-        log.info('Device: ', addr)
+        log.info('Device: %s', addr)
 
     log.info('Replying with Device Status Record')
     log.info('__________________________________')
     plm.devices['4d5e6f'].states[0x01].async_refresh_state()
+    yield from asyncio.sleep(.1)
     msg = insteonplm.messages.standardSend.StandardSend(
         address='4d5e6f', commandtuple={'cmd1': 0x19, 'cmd2': 0x00},
         flags=0x00, acknak=0x06)

--- a/tests/test_sensorsActuators.py
+++ b/tests/test_sensorsActuators.py
@@ -20,7 +20,7 @@ def test_SensorsActuators_2450_status():
     """Test SensorActuator device model 2450."""
     def run_test(loop):
         """Asyncio test run."""
-        plm = MockPLM()
+        plm = MockPLM(loop)
         address = '1a2b3c'
         target = '4d5e6f'
 
@@ -34,7 +34,7 @@ def test_SensorsActuators_2450_status():
 
         device = SensorsActuators_2450.create(plm, address, cat, subcat,
                                               product_key, description, model)
-
+        plm.devices[address] = device
         assert device.states[0x01].name == 'openClosedRelay'
         assert device.states[0x02].name == 'openClosedSensor'
 

--- a/tests/test_switchedLightingControl.py
+++ b/tests/test_switchedLightingControl.py
@@ -17,6 +17,9 @@ from insteonplm.devices.switchedLightingControl import (
 from .mockPLM import MockPLM
 from .mockCallbacks import MockCallbacks
 
+import logging
+_LOGGING = logging.getLogger()
+_LOGGING.setLevel(logging.DEBUG)
 
 def test_switchedLightingControl():
     """Test SwitchedLightingControl."""
@@ -33,7 +36,7 @@ def test_switchedLightingControl():
 
         device = SwitchedLightingControl(plm, address, cat, subcat,
                                          product_key, description, model)
-
+        plm.devices[address] = device
         assert device.address.hex == address
         assert device.cat == cat
         assert device.subcat == subcat
@@ -95,7 +98,7 @@ def test_switchedLightingControl_maual_changes():
 
         device = SwitchedLightingControl(plm, address, cat, subcat,
                                          product_key, description, model)
-
+        plm.devices[address] = device
         assert device.address.hex == address
         assert device.cat == cat
         assert device.subcat == subcat
@@ -142,7 +145,7 @@ def test_switchedLightingControl_status():
 
         device = SwitchedLightingControl(plm, address, cat, subcat,
                                          product_key, description, model)
-
+        plm.devices[address] = device
         assert device.address.hex == address
         assert device.cat == cat
         assert device.subcat == subcat
@@ -193,7 +196,7 @@ def test_switchedLightingControl_2663_222():
 
         device = SwitchedLightingControl_2663_222(
             plm, address, cat, subcat, product_key, description, model)
-
+        plm.devices[address] = device
         assert device.address.hex == address
         assert device.cat == cat
         assert device.subcat == subcat
@@ -294,7 +297,7 @@ def test_switchedLightingControl_2663_222_manual_change():
 
         device = SwitchedLightingControl_2663_222(
             plm, address, cat, subcat, product_key, description, model)
-
+        plm.devices[address] = device
         assert device.address.hex == address
         assert device.cat == cat
         assert device.subcat == subcat
@@ -375,7 +378,7 @@ def test_switchedLightingControl_2663_222_status():
 
         device = SwitchedLightingControl_2663_222.create(
             mockPLM, address, cat, subcat, product_key, description, model)
-
+        mockPLM.devices[address] = device
         assert device.states[0x01].name == 'outletTopOnOff'
         assert device.states[0x02].name == 'outletBottomOnOff'
 


### PR DESCRIPTION
This PR fixes an issue with startup where temporary devices (i.e. UnknownDevice) register callbacks but then go away to be replaced by an instance of the true device. The issue is the callbacks represent a reference to the UnknownDevice and therefore remain in PLM message callbacks. 

This change moves the device specific message callbacks to the device rather than the PLM. Therefore the flow of an inbound message is now:
PLM->Device->callback method. 