### PR TITLE
Rename ALDB to LInkedDevices and create a device ALDB

### DIFF
--- a/insteonplm/devices/generalController.py
+++ b/insteonplm/devices/generalController.py
@@ -1,5 +1,5 @@
 """INSTEON General Controller Device Class."""
-from insteonplm.devices import Device
+from insteonplm.devices import Device, ALDB, ALDBVersion
 
 
 class GeneralController(Device):
@@ -9,3 +9,9 @@ class GeneralController(Device):
 
     Example: ControLinc, RemoteLinc, SignaLinc, etc.
     """
+ 
+    def __init__(self, plm, address, cat, subcat, product_key=0,
+                 description='', model=''):
+        super().__init__(plm, address, cat, subcat, product_key,
+                         description, model)
+        self._aldb = ALDB(None, None, self._address, version=ALDBVersion.Null)

--- a/insteonplm/devices/unknowndevice.py
+++ b/insteonplm/devices/unknowndevice.py
@@ -1,5 +1,5 @@
 """INSTEON Device Unknown Device Type."""
-from insteonplm.devices import Device
+from insteonplm.devices import Device, ALDB, ALDBVersion
 
 
 class UnknownDevice(Device):
@@ -26,3 +26,4 @@ class UnknownDevice(Device):
         self._noRegisterCallback = False
         super().__init__(plm, address, cat, subcat, product_key,
                          description, model)
+        self._aldb = ALDB(None, None, self._address, version=ALDBVersion.Null)

--- a/insteonplm/linkedDevices.py
+++ b/insteonplm/linkedDevices.py
@@ -13,7 +13,7 @@ __all__ = ('ALDB')
 DEVICE_INFO_FILE = 'insteon_plm_device_info.dat'
 
 
-class ALDB(object):
+class LinkedDevices(object):
     """Class holds and maintains the ALL-Link Database from the PLM device."""
 
     def __init__(self, loop=None, workdir=None):

--- a/insteonplm/tools.py
+++ b/insteonplm/tools.py
@@ -6,7 +6,7 @@ import logging
 
 import insteonplm
 from insteonplm.address import Address
-from insteonplm.devices import Device
+from insteonplm.devices import Device, ALDBStatus
 
 __all__ = ('Tools', 'monitor', 'all_linking')
 

--- a/tests/mockPLM.py
+++ b/tests/mockPLM.py
@@ -1,7 +1,7 @@
 """Mock PLM class for testing devices."""
 import logging
 from insteonplm.messagecallback import MessageCallback
-from insteonplm.aldb import ALDB
+from insteonplm.linkedDevices import LinkedDevices
 
 
 class MockPLM(object):
@@ -13,7 +13,7 @@ class MockPLM(object):
         self.sentmessage = ''
         self._message_callbacks = MessageCallback()
         self.loop = loop
-        self.devices = ALDB()
+        self.devices = LinkedDevices()
 
     @property
     def message_callbacks(self):

--- a/tests/test_linkedDevices.py
+++ b/tests/test_linkedDevices.py
@@ -1,6 +1,6 @@
 """Test insteonplm ALDB Class."""
 from insteonplm.address import Address
-from insteonplm.aldb import ALDB
+from insteonplm.linkedDevices import LinkedDevices
 from insteonplm.devices.switchedLightingControl import SwitchedLightingControl
 from .mockPLM import MockPLM
 
@@ -14,9 +14,9 @@ def test_create_device_from_category():
 
     description = 'Icon SwitchLinc Relay (Lixar)'
     model = '2676R-B'
-
-    aldb = ALDB()
-    dev = aldb.create_device_from_category(plm, addr, cat, subcat)
+    
+    linkedDevices = LinkedDevices()
+    dev = linkedDevices.create_device_from_category(plm, addr, cat, subcat)
 
     assert isinstance(dev, SwitchedLightingControl)
     assert dev.cat == cat
@@ -34,9 +34,9 @@ def test_create_device_from_category_generic_device():
 
     description = 'Generic Switched Lighting Control'
     model = ''
-
-    aldb = ALDB()
-    dev = aldb.create_device_from_category(plm, addr, cat, subcat)
+    
+    linkedDevices = LinkedDevices()
+    dev = linkedDevices.create_device_from_category(plm, addr, cat, subcat)
 
     assert isinstance(dev, SwitchedLightingControl)
     assert dev.cat == cat


### PR DESCRIPTION
In preparation for All-Linking, this creates a device specific ALDB. The PLM ALDB is renamed to LinkedDevices since it is not really the ALDB of the PLM. 