### PR TITLE
Fix rare issue where the a device stop responding

### DIFF
--- a/insteonplm/devices/__init__.py
+++ b/insteonplm/devices/__init__.py
@@ -8,7 +8,7 @@ import logging
 
 from insteonplm.address import Address
 from insteonplm.constants import (
-    MESSAGE_ACK, COMMAND_ID_REQUEST_0X10_0X00,
+    COMMAND_ID_REQUEST_0X10_0X00,
     COMMAND_PRODUCT_DATA_REQUEST_0X03_0X00,
     COMMAND_ASSIGN_TO_ALL_LINK_GROUP_0X01_NONE,
     COMMAND_DELETE_FROM_ALL_LINK_GROUP_0X02_NONE,
@@ -24,7 +24,6 @@ from insteonplm.messagecallback import MessageCallback
 from insteonplm.messages.extendedReceive import ExtendedReceive
 from insteonplm.messages.extendedSend import ExtendedSend
 from insteonplm.messages.messageFlags import MessageFlags
-from insteonplm.messages.standardReceive import StandardReceive
 from insteonplm.messages.standardSend import StandardSend
 from insteonplm.messages.userdata import Userdata
 from insteonplm.states import State
@@ -177,15 +176,15 @@ class Device(object):
         The default is group 0x01.
         """
         msg = StandardSend(self._address,
-                                COMMAND_ASSIGN_TO_ALL_LINK_GROUP_0X01_NONE,
-                                cmd2=group)
+                           COMMAND_ASSIGN_TO_ALL_LINK_GROUP_0X01_NONE,
+                           cmd2=group)
         self._send_msg(msg)
 
     def delete_from_all_link_group(self, group):
         """Delete a device to an All-Link Group."""
         msg = StandardSend(self._address,
-                                COMMAND_DELETE_FROM_ALL_LINK_GROUP_0X02_NONE,
-                                cmd2=group)
+                           COMMAND_DELETE_FROM_ALL_LINK_GROUP_0X02_NONE,
+                           cmd2=group)
         self._send_msg(msg)
 
     def fx_username(self):
@@ -215,8 +214,8 @@ class Device(object):
         Not supported by i1 devices.
         """
         msg = StandardSend(self._address,
-                                COMMAND_ENTER_LINKING_MODE_0X09_NONE,
-                                cmd2=group)
+                           COMMAND_ENTER_LINKING_MODE_0X09_NONE,
+                           cmd2=group)
         self._send_msg(msg)
 
     def enter_unlinking_mode(self, group):
@@ -225,8 +224,8 @@ class Device(object):
         Not supported by i1 devices.
         """
         msg = StandardSend(self._address,
-                                COMMAND_ENTER_UNLINKING_MODE_0X0A_NONE,
-                                cmd2=group)
+                           COMMAND_ENTER_UNLINKING_MODE_0X0A_NONE,
+                           cmd2=group)
         self._send_msg(msg)
 
     def get_engine_version(self):
@@ -253,7 +252,7 @@ class Device(object):
     def write_aldb(self, mem_addr: int, mode: str, group: int, target,
                    data1=0x00, data2=0x00, data3=0x00):
         """Write to the device All-Link Database.
-        
+
         Paramters:
             Required:
             mode:   r - device is a responder of target
@@ -295,7 +294,7 @@ class Device(object):
                     messageType=MESSAGE_TYPE_DIRECT_MESSAGE,
                     extended=1))
             self._message_callbacks.add(ext_msg_aldb_record,
-                                            self._handle_aldb_record_received)
+                                        self._handle_aldb_record_received)
 
     # Send / Receive message processing
     def receive_message(self, msg):
@@ -307,17 +306,18 @@ class Device(object):
                 coro = self._wait_for_direct_ACK()
                 asyncio.ensure_future(coro, loop=self._plm.loop)
             else:
-                self.log.debug('DA queue: %s', self._sent_msg_wait_for_directACK)
+                self.log.debug('DA queue: %s',
+                               self._sent_msg_wait_for_directACK)
                 self.log.debug('Message ACK with no callback')
-        if (hasattr(msg, 'flags')
-                and hasattr(msg.flags, 'isDirectACK')
-                and msg.flags.isDirectACK):
+        if (hasattr(msg, 'flags') and
+                hasattr(msg.flags, 'isDirectACK') and
+                msg.flags.isDirectACK):
             self.log.debug('Got Direct ACK message')
             if self._send_msg_lock.locked():
-                self.log.debug('Lock is locked')
                 self._directACK_received_queue.put_nowait(msg)
+            else:
+                self.log.debug('But Direct ACK not expected')
         callbacks = self._message_callbacks.get_callbacks_from_message(msg)
-        self.log.debug('Found %d callbacks for msg %s', len(callbacks), msg)
         for callback in callbacks:
             self.log.debug('Scheduling msg callback: %s', callback)
             self._plm.loop.call_soon(callback, msg)
@@ -345,7 +345,6 @@ class Device(object):
                                                  'on_timeout': on_timeout}
         self._plm.send_msg(msg)
         self.log.debug('Ending Device._process_send_queue')
-
 
     @asyncio.coroutine
     def _wait_for_direct_ACK(self):
@@ -624,6 +623,7 @@ class ALDBVersion(Enum):
 
 LoadAction = collections.namedtuple('LoadAction', 'mem_addr rec_count retries')
 
+
 class ALDB(object):
     """Represents a device All-Link database."""
 
@@ -640,7 +640,7 @@ class ALDB(object):
         self._loop = loop
         self._address = address
         self._mem_addr = mem_addr
-        
+
         self._rec_mgr_lock = asyncio.Lock(loop=self._loop)
         self._load_action = LoadAction(0, 0, 0)
         self._cb_aldb_loaded = []
@@ -690,7 +690,7 @@ class ALDB(object):
 
     def add_loaded_callback(self, callback):
         """Add a callback to be run when the ALDB load is complete."""
-        if not callback in self._cb_aldb_loaded:
+        if callback not in self._cb_aldb_loaded:
             self._cb_aldb_loaded.append(callback)
 
     @asyncio.coroutine
@@ -721,7 +721,7 @@ class ALDB(object):
                 log_output = '{:s} all records'.format(log_output)
 
             if retry:
-                log_output = '{:s} retry {:d} of {:d}'.format(log_output, 
+                log_output = '{:s} retry {:d} of {:d}'.format(log_output,
                                                               retry,
                                                               max_retries)
             self.log.info(log_output)
@@ -764,10 +764,10 @@ class ALDB(object):
             addr_lo = addr.bytes[0]
             addr_mid = addr.bytes[1]
             addr_hi = addr.bytes[2]
-            chksum = 0xff - ((0x2f + 0x02 + mem_hi + mem_lo + 0x08
-                              + control_flag.byte
-                              + addr_lo + addr_mid + addr_hi
-                              + group + data1 + data2 + data3) & 0xff) + 1
+            chksum = 0xff - ((0x2f + 0x02 + mem_hi + mem_lo + 0x08 +
+                              control_flag.byte +
+                              addr_lo + addr_mid + addr_hi +
+                              group + data1 + data2 + data3) & 0xff) + 1
             userdata = Userdata({'d1': 0,
                                  'd2': 0x02,
                                  'd3': mem_hi,
@@ -810,8 +810,8 @@ class ALDB(object):
                 else:
                     mode_test = rec.control_flags.is_responder
                 if (mode_test and
-                    rec.group == link_group and
-                    rec.address == link_addr):
+                        rec.group == link_group and
+                        rec.address == link_addr):
                     found_rec = rec
         return found_rec
 
@@ -821,7 +821,7 @@ class ALDB(object):
         userdata = msg.userdata
         rec = ALDBRecord.create_from_userdata(userdata)
         self._records[rec.mem_addr] = rec
-        
+
         self.log.debug('ALDB Record: %s', rec)
 
         rec_count = self._load_action.rec_count
@@ -889,20 +889,20 @@ class ALDB(object):
                 read_complete = True
         except asyncio.TimeoutError:
             if (self._load_action.rec_count and
-                self._load_action.mem_addr == 0x0000 and
-                self._have_first_record()):
+                    self._load_action.mem_addr == 0x0000 and
+                    self._have_first_record()):
                 read_complete = False
             elif self.get(self._load_action.mem_addr):
                 read_complete = True
             else:
                 self.log.debug('ALDB record response timeout.')
                 read_complete = False
-        
+
         self._set_load_action(self._load_action.mem_addr,
                               self._load_action.rec_count,
                               self._load_action.retries,
                               read_complete)
-        
+
         mem_addr = self._load_action.mem_addr
         rec_count = self._load_action.rec_count
         retries = self._load_action.retries
@@ -911,17 +911,19 @@ class ALDB(object):
             self._rec_mgr_lock.release()
 
         if mem_addr is not None:
-            asyncio.ensure_future(self.load(mem_addr, rec_count, retries), 
+            asyncio.ensure_future(self.load(mem_addr, rec_count, retries),
                                   loop=self._loop)
         elif read_complete or self._have_all_records():
             self.log.info('ALDB load complete for device %s', self._address)
             self._load_finished(ALDBStatus.LOADED)
         else:
             if self._records:
-                self.log.warning('ALDB partially loaded for device %s', self._address)
+                self.log.warning('ALDB partially loaded for device %s',
+                                 self._address)
                 self._load_finished(ALDBStatus.PARTIAL)
             else:
-                self.log.warning('ALDB failed to load for device %s', self._address)
+                self.log.warning('ALDB failed to load for device %s',
+                                 self._address)
                 self._load_finished(ALDBStatus.FAILED)
 
     def _load_finished(self, status):
@@ -977,14 +979,14 @@ class ALDB(object):
         self._load_action = LoadAction(mem_addr, rec_count,  retries)
         if mem_addr is not None:
             self.log.debug('Load action: addr: %04x rec_count: %d retries: %d',
-                          self._load_action.mem_addr,
-                          self._load_action.rec_count,
-                          self._load_action.retries)
+                           self._load_action.mem_addr,
+                           self._load_action.rec_count,
+                           self._load_action.retries)
 
     def _next_address(self, mem_addr):
         if self._have_first_record() and mem_addr == 0x0000:
             mem_addr = self._mem_addr
-        while self.get(mem_addr): 
+        while self.get(mem_addr):
             if self.get(mem_addr).control_flags.is_high_water_mark:
                 mem_addr = None
             else:

--- a/insteonplm/plm.py
+++ b/insteonplm/plm.py
@@ -23,7 +23,7 @@ from insteonplm.messages.startAllLinking import StartAllLinking
 from insteonplm.devices import Device, ALDBRecord, ALDBStatus
 
 __all__ = ('PLM, Hub')
-WAIT_TIMEOUT = 2
+WAIT_TIMEOUT = 1.5
 ACKNAK_TIMEOUT = 2
 
 

--- a/insteonplm/plm.py
+++ b/insteonplm/plm.py
@@ -239,10 +239,13 @@ class IM(Device, asyncio.Protocol):
                     is_nak = False
                     try:
                         with async_timeout.timeout(ACKNAK_TIMEOUT):
-                            acknak = yield from self._acknak_queue.get()
-                            self.log.debug('ACK or NAK received')
-                            self.log.debug(acknak)
-                            is_nak = acknak.isnak
+                            while True:
+                                acknak = yield from self._acknak_queue.get()
+                                if msg.matches_pattern(acknak):
+                                    self.log.debug('ACK or NAK received')
+                                    self.log.debug(acknak)
+                                    is_nak = acknak.isnak
+                                break
                     except asyncio.TimeoutError:
                         self.log.debug('No ACK or NAK message received.')
                         is_nak = True

--- a/insteonplm/plm.py
+++ b/insteonplm/plm.py
@@ -23,8 +23,8 @@ from insteonplm.messages.startAllLinking import StartAllLinking
 from insteonplm.devices import Device, ALDBRecord, ALDBStatus
 
 __all__ = ('PLM, Hub')
-WAIT_TIMEOUT = 1
-ACKNAK_TIMEOUT = .6
+WAIT_TIMEOUT = 1.5
+ACKNAK_TIMEOUT = 1
 
 
 class IM(Device, asyncio.Protocol):

--- a/insteonplm/plm.py
+++ b/insteonplm/plm.py
@@ -23,8 +23,8 @@ from insteonplm.messages.startAllLinking import StartAllLinking
 from insteonplm.devices import Device, ALDBRecord, ALDBStatus
 
 __all__ = ('PLM, Hub')
-WAIT_TIMEOUT = 1.5
-ACKNAK_TIMEOUT = 1
+WAIT_TIMEOUT = 2
+ACKNAK_TIMEOUT = 2
 
 
 class IM(Device, asyncio.Protocol):

--- a/insteonplm/plm.py
+++ b/insteonplm/plm.py
@@ -15,17 +15,16 @@ from insteonplm.linkedDevices import LinkedDevices
 from insteonplm.messagecallback import MessageCallback
 from insteonplm.messages.allLinkComplete import AllLinkComplete
 from insteonplm.messages.allLinkRecordResponse import AllLinkRecordResponse
-from insteonplm.messages.extendedSend import ExtendedSend
 from insteonplm.messages.getFirstAllLinkRecord import GetFirstAllLinkRecord
 from insteonplm.messages.getIMInfo import GetImInfo
 from insteonplm.messages.getNextAllLinkRecord import GetNextAllLinkRecord
 from insteonplm.messages.standardReceive import StandardReceive
-from insteonplm.messages.standardSend import StandardSend
 from insteonplm.messages.startAllLinking import StartAllLinking
 from insteonplm.devices import Device, ALDBRecord, ALDBStatus
 
 __all__ = ('PLM, Hub')
-WAIT_TIMEOUT = 2
+WAIT_TIMEOUT = 1
+ACKNAK_TIMEOUT = .6
 
 
 class IM(Device, asyncio.Protocol):
@@ -58,7 +57,7 @@ class IM(Device, asyncio.Protocol):
         self._buffer = bytearray()
         self._recv_queue = deque([])
         self._send_queue = asyncio.Queue(loop=self._loop)
-        self._wait_acknack_queue = []
+        self._acknak_queue = asyncio.Queue(loop=self._loop)
         self._aldb_response_queue = {}
         self._devices = LinkedDevices(loop, workdir)
         self._poll_devices = poll_devices
@@ -124,6 +123,8 @@ class IM(Device, asyncio.Protocol):
                 self.log.debug('Processing message %s', msg)
                 callbacks = \
                     self._message_callbacks.get_callbacks_from_message(msg)
+                if hasattr(msg, 'isack') or hasattr(msg, 'isnak'):
+                    self._acknak_queue.put_nowait(msg)
                 if hasattr(msg, 'address'):
                     device = self.devices[msg.address.hex]
                     if device:
@@ -172,14 +173,17 @@ class IM(Device, asyncio.Protocol):
             device = self.devices[addr]
             device.async_refresh_state()
 
-    def send_msg(self, msg):
+    def send_msg(self, msg, wait_nak=True, wait_timeout=WAIT_TIMEOUT):
         """Place a message on the send queue for sending.
 
         Message are sent in the order they are placed in the queue.
         """
         self.log.debug("Starting: send_msg")
         write_message_coroutine = self._write_message_from_send_queue()
-        self._send_queue.put_nowait(msg)
+        wait_info = {'msg': msg,
+                     'wait_nak': wait_nak,
+                     'wait_timeout': wait_timeout}
+        self._send_queue.put_nowait(wait_info)
         asyncio.ensure_future(write_message_coroutine, loop=self._loop)
         self.log.debug("Ending: send_msg")
 
@@ -214,25 +218,44 @@ class IM(Device, asyncio.Protocol):
             self.log.debug('Aquiring write lock')
             yield from self._write_transport_lock.acquire()
             while True:
-                self.log.debug(self._write_transport_lock.locked())
                 # wait for an item from the queue
                 try:
                     with async_timeout.timeout(WAIT_TIMEOUT):
-                        msg = yield from self._send_queue.get()
+                        msg_info = yield from self._send_queue.get()
+                        msg = msg_info.get('msg')
+                        wait_nak = msg_info.get('wait_nak')
+                        wait_timeout = msg_info.get('wait_timeout')
                 except asyncio.TimeoutError:
                     self.log.debug('No new messages received.')
                     break
                 # process the item
                 self.log.debug('Writing message: %s', msg)
+                write_bytes = msg.bytes
+                if hasattr(msg, 'acknak') and msg.acknak:
+                    write_bytes = write_bytes[:-1]
                 self.transport.write(msg.bytes)
-                yield from asyncio.sleep(1.5, loop=self._loop)
+                if wait_nak:
+                    self.log.debug('Waiting for ACK or NAK message')
+                    is_nak = False
+                    try:
+                        with async_timeout.timeout(ACKNAK_TIMEOUT):
+                            acknak = yield from self._acknak_queue.get()
+                            self.log.debug('ACK or NAK received')
+                            self.log.debug(acknak)
+                            is_nak = acknak.isnak
+                    except asyncio.TimeoutError:
+                        self.log.debug('No ACK or NAK message received.')
+                        is_nak = True
+                    if is_nak:
+                        self._handle_nak(msg)
+                yield from asyncio.sleep(wait_timeout, loop=self._loop)
             self._write_transport_lock.release()
 
     def _get_plm_info(self):
         """Request PLM Info."""
         self.log.info('Requesting PLM Info')
         msg = GetImInfo()
-        self.send_msg(msg)
+        self.send_msg(msg, wait_nak=True, wait_timeout=.5)
 
     def _load_all_link_database(self):
         """Load the ALL-Link Database into object."""
@@ -246,7 +269,7 @@ class IM(Device, asyncio.Protocol):
         self.log.debug("Starting: _get_first_all_link_record")
         self.log.info('Requesting ALL-Link Records')
         msg = GetFirstAllLinkRecord()
-        self.send_msg(msg)
+        self.send_msg(msg, wait_nak=True, wait_timeout=.5)
         self.log.debug("Ending: _get_first_all_link_record")
 
     def _get_next_all_link_record(self):
@@ -254,14 +277,11 @@ class IM(Device, asyncio.Protocol):
         self.log.debug("Starting: _get_next_all_link_recor")
         self.log.debug("Requesting Next All-Link Record")
         msg = GetNextAllLinkRecord()
-        self.send_msg(msg)
+        self.send_msg(msg, wait_nak=True, wait_timeout=.5)
         self.log.debug("Ending: _get_next_all_link_recor")
 
     # Inbound message handlers sepcific to the IM
     def _register_message_handlers(self):
-        template_std_msg_nak = StandardSend.template(acknak=MESSAGE_NAK)
-        template_ext_msg_nak = ExtendedSend.template(acknak=MESSAGE_NAK)
-
         template_assign_all_link = StandardReceive.template(
             commandtuple=COMMAND_ASSIGN_TO_ALL_LINK_GROUP_0X01_NONE)
         template_all_link_response = AllLinkRecordResponse(None, None, None,
@@ -270,13 +290,6 @@ class IM(Device, asyncio.Protocol):
         template_next_all_link_rec = GetNextAllLinkRecord(acknak=MESSAGE_NAK)
         template_all_link_complete = AllLinkComplete(None, None, None,
                                                      None, None, None)
-
-        self._message_callbacks.add(
-            template_std_msg_nak,
-            self._handle_standard_or_extended_message_nak)
-        self._message_callbacks.add(
-            template_ext_msg_nak,
-            self._handle_standard_or_extended_message_nak)
 
         self._message_callbacks.add(
             template_assign_all_link,
@@ -383,7 +396,7 @@ class IM(Device, asyncio.Protocol):
                 else:
                     if rec.address == self.address and rec.group == group:
                         self.log.info('Removing record %04x with addr %s and '
-                                      'group %d', mem_addr, rec.address, 
+                                      'group %d', mem_addr, rec.address,
                                       rec.group)
                         device.aldb.pop(mem_addr)
             device.read_aldb()
@@ -492,8 +505,12 @@ class IM(Device, asyncio.Protocol):
                 self._loop.call_soon(self.poll_devices)
         self.log.debug('Ending _handle_get_next_all_link_record_nak')
 
-    def _handle_standard_or_extended_message_nak(self, msg):
-        msg.acknak = None
+    def _handle_nak(self, msg):
+        if msg.code == GetFirstAllLinkRecord.code or \
+           msg.code == GetNextAllLinkRecord.code:
+            return
+        self.log.debug('No response or NAK message received for message')
+        self.log.debug(msg)
         self.send_msg(msg)
 
     def _handle_get_plm_info(self, msg):

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ if len(long_description) < 100:
 
 setup(
     name='insteonplm',
-    version='0.9.1',
+    version='0.8.6',
     author='David McNett',
     author_email='nugget@macnugget.org',
     url='https://github.com/nugget/python-insteonplm',

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -35,7 +35,7 @@ def test_create_device_from_bytearray():
     assert isinstance(device, DimmableLightingControl)
 
 
-def test_send_msg(logger, caplog):
+def test_send_msg():
 
     @asyncio.coroutine
     def run_test(loop):
@@ -64,7 +64,7 @@ def test_send_msg(logger, caplog):
             address, COMMAND_LIGHT_ON_0X11_NONE, cmd2=0xff, flags=0x00).hex
 
         # Sleep until the Direct ACK time out should expire
-        yield from asyncio.sleep(DIRECT_ACK_WAIT_TIMEOUT + 2,
+        yield from asyncio.sleep(DIRECT_ACK_WAIT_TIMEOUT + .2,
                                  loop=loop)
 
         # Confirm that the OFF command made it to the PLM

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1,7 +1,17 @@
 """Test insteonplm.evices module."""
+import asyncio
+import logging
+
+from insteonplm.constants import (COMMAND_LIGHT_OFF_0X13_0X00,
+                                  COMMAND_LIGHT_ON_0X11_NONE,
+                                  MESSAGE_ACK)
+from insteonplm.messages.standardSend import StandardSend
 import insteonplm.devices
 from insteonplm.devices.dimmableLightingControl import DimmableLightingControl
-from .mockPLM import MockPLM
+from tests.mockPLM import MockPLM
+from insteonplm.devices import DIRECT_ACK_WAIT_TIMEOUT
+
+_LOGGING = logging.getLogger(__name__)
 
 
 def test_create_device():
@@ -23,3 +33,43 @@ def test_create_device_from_bytearray():
                                        None)
     assert device.id == '112233'
     assert isinstance(device, DimmableLightingControl)
+
+
+def test_send_msg(logger, caplog):
+
+    @asyncio.coroutine
+    def run_test(loop):
+        mockPLM = MockPLM(loop)
+        address = '1a2b3c'
+        device = insteonplm.devices.create(mockPLM, address, 0x01, 0x0d, 0x44)
+        mockPLM.devices[address] = device
+
+        # Send the ON command. This should be sent directly to the PLM
+        device.states[0x01].on()
+        yield from asyncio.sleep(.1, loop=loop)
+
+        # Send the OFF command. This should wait in queue until the
+        # Direct ACK timeout
+        device.states[0x01].off()
+        yield from asyncio.sleep(.1, loop=loop)
+
+        # ACK the ON command
+        msgreceived = StandardSend(address, COMMAND_LIGHT_ON_0X11_NONE,
+                                   cmd2=0xff, flags=0x00, acknak=MESSAGE_ACK)
+        mockPLM.message_received(msgreceived)
+        asyncio.sleep(.1, loop=loop)
+
+        _LOGGING.debug('Assert that the ON command is the command in the PLM')
+        assert mockPLM.sentmessage == StandardSend(
+            address, COMMAND_LIGHT_ON_0X11_NONE, cmd2=0xff, flags=0x00).hex
+
+        # Sleep until the Direct ACK time out should expire
+        yield from asyncio.sleep(DIRECT_ACK_WAIT_TIMEOUT + 2,
+                                 loop=loop)
+
+        # Confirm that the OFF command made it to the PLM
+        assert mockPLM.sentmessage == StandardSend(
+            address, COMMAND_LIGHT_OFF_0X13_0X00).hex
+
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(run_test(loop))

--- a/tests/test_plm.py
+++ b/tests/test_plm.py
@@ -1,12 +1,44 @@
 """Test the INSTEON PLM device."""
 import asyncio
+import async_timeout
 import logging
 import binascii
 
 import insteonplm
-from insteonplm.constants import MESSAGE_FLAG_BROADCAST_0X80
+from insteonplm.constants import (COMMAND_LIGHT_ON_0X11_NONE,
+                                  COMMAND_LIGHT_OFF_0X13_0X00,
+                                  MESSAGE_FLAG_BROADCAST_0X80,
+                                  COMMAND_ID_REQUEST_0X10_0X00,
+                                  COMMAND_LIGHT_STATUS_REQUEST_0X19_0X00,
+                                  MESSAGE_NAK,
+                                  MESSAGE_ACK)
 from insteonplm.plm import PLM
 from insteonplm.address import Address
+from insteonplm.messages.standardSend import StandardSend
+from insteonplm.messages.standardReceive import StandardReceive
+from insteonplm.messages.getIMInfo import GetImInfo
+from insteonplm.messages.getFirstAllLinkRecord import GetFirstAllLinkRecord
+from insteonplm.messages.getNextAllLinkRecord import GetNextAllLinkRecord
+from insteonplm.messages.allLinkRecordResponse import AllLinkRecordResponse
+
+_LOGGER = logging.getLogger()
+SEND_MSG_WAIT = 1.1
+SEND_MSG_ACKNAK_WAIT = .2
+DIRECT_ACK_WAIT_TIMEOUT = 3.1
+RECV_MSG_WAIT = .1
+
+
+@asyncio.coroutine
+def wait_for_plm_command(plm, cmd, loop):
+    try:
+        with async_timeout.timeout(10, loop=loop):
+            while not plm.transport.lastmessage == cmd.hex:
+                yield from asyncio.sleep(.1, loop=loop)
+            _LOGGER.info('Expected message sent %s', cmd)
+            return True
+    except asyncio.TimeoutError:
+        _LOGGER.error('Expected message not sent %s', cmd)
+        return False
 
 
 # pylint: disable=too-few-public-methods
@@ -15,7 +47,6 @@ class MockConnection():
 
     def __init__(self):
         """Instantiate the Connection object."""
-        self.log = logging.getLogger(__name__)
         self.loop = None
         self.protocol = None
         self.transport = None
@@ -36,7 +67,6 @@ class MockConnection():
 
             def __init__(self):
                 """Initialize the mock Serial class."""
-                self.log = logging.getLogger(__name__)
                 self.write_timeout = 0
                 self.timeout = 0
 
@@ -45,7 +75,6 @@ class MockConnection():
 
             def __init__(self):
                 """Initialize the mock Transport class."""
-                self.log = logging.getLogger(__name__)
                 self.serial = Serial()
                 self.lastmessage = None
                 self._mock_buffer_size = 128
@@ -60,124 +89,174 @@ class MockConnection():
 
             def write(self, data):
                 """Mock write data to the Connection."""
-                self.lastmessage = data
-                self.log.info('Message sent: %s',
-                              binascii.hexlify(self.lastmessage))
+                self.lastmessage = binascii.hexlify(data).decode()
+                _LOGGER.info('Message sent: %s', self.lastmessage)
 
         conn.transport = Transport()
         return conn
 
 
 @asyncio.coroutine
-def do_plm(loop, log, devicelist):
+def do_plm(loop):
     """Asyncio coroutine to test the PLM."""
-    log.info('Connecting to Insteon PLM')
+    _LOGGER.info('Connecting to Insteon PLM')
 
     # pylint: disable=not-an-iterable
     conn = yield from MockConnection.create(loop=loop)
 
     def async_insteonplm_light_callback(device):
         """Log that our new device callback worked."""
-        log.warn('New Device: %s %02x %02x %s, %s', device.id, device.cat,
-                 device.subcat, device.description, device.model)
+        _LOGGER.warn('New Device: %s %02x %02x %s, %s', device.id, device.cat,
+                     device.subcat, device.description, device.model)
 
     def async_light_on_level_callback(device_id, state, value):
         """Callback to catch changes to light value."""
-        log.info('Device %s state %s value is changed to %02x',
-                 device_id, state, value)
+        _LOGGER.info('Device %s state %s value is changed to %02x',
+                     device_id, state, value)
 
     conn.protocol.add_device_callback(async_insteonplm_light_callback)
 
     plm = conn.protocol
     plm.connection_made(conn.transport)
 
-    log.info('Replying with IM Info')
-    log.info('_____________________')
+    _LOGGER.info('Replying with IM Info')
+    _LOGGER.info('_____________________')
+    cmd_sent = yield from wait_for_plm_command(plm, GetImInfo(), loop)
+    if not cmd_sent:
+        assert False
     msg = insteonplm.messages.getIMInfo.GetImInfo(address='1a2b3c', cat=0x03,
                                                   subcat=0x20, firmware=0x00,
-                                                  acknak=0x06)
+                                                  acknak=MESSAGE_ACK)
     plm.data_received(msg.bytes)
-    yield from asyncio.sleep(.1)
+    yield from asyncio.sleep(RECV_MSG_WAIT)
     assert plm.address == Address('1a2b3c')
     assert plm.cat == 0x03
     assert plm.subcat == 0x20
     assert plm.product_key == 0x00
 
-    log.info('Replying with an All-Link Record')
-    log.info('________________________________')
-    msg = insteonplm.messages.allLinkRecordResponse.AllLinkRecordResponse(
+    _LOGGER.info('Replying with an All-Link Record')
+    _LOGGER.info('________________________________')
+    cmd_sent = yield from wait_for_plm_command(plm, GetFirstAllLinkRecord(),
+                                               loop)
+    if not cmd_sent:
+        assert False
+    msg = GetFirstAllLinkRecord(MESSAGE_ACK)
+    plm.data_received(msg.bytes)
+    yield from asyncio.sleep(RECV_MSG_WAIT)
+
+    msg = AllLinkRecordResponse(
         flags=0x00, group=0x01, address='4d5e6f',
         linkdata1=0x01, linkdata2=0x0b, linkdata3=0x000050)
     plm.data_received(msg.bytes)
-    yield from asyncio.sleep(.1)
+    yield from asyncio.sleep(RECV_MSG_WAIT)
 
-    log.info('Replying with Last All-Link Record')
-    log.info('__________________________________')
-    msg = insteonplm.messages.getNextAllLinkRecord.GetNextAllLinkRecord(0x15)
+    _LOGGER.info('Replying with Last All-Link Record')
+    _LOGGER.info('__________________________________')
+    cmd_sent = yield from wait_for_plm_command(plm, GetNextAllLinkRecord(),
+                                               loop)
+    if not cmd_sent:
+        assert False
+    msg = GetNextAllLinkRecord(MESSAGE_NAK)
     plm.data_received(msg.bytes)
-    yield from asyncio.sleep(.1)
+    yield from asyncio.sleep(RECV_MSG_WAIT)
 
-    log.info('Replying with Device Info Record')
-    log.info('________________________________')
-    msg = insteonplm.messages.standardReceive.StandardReceive(
+    _LOGGER.info('Replying with Device Info Record')
+    _LOGGER.info('________________________________')
+    msg = StandardSend('4d5e6f', COMMAND_ID_REQUEST_0X10_0X00)
+    cmd_sent = wait_for_plm_command(plm, msg, loop)
+    if not cmd_sent:
+        assert False
+    msg = StandardSend('4d5e6f', COMMAND_ID_REQUEST_0X10_0X00,
+                       acknak=MESSAGE_ACK)
+    plm.data_received(msg.bytes)
+    yield from asyncio.sleep(RECV_MSG_WAIT, loop=loop)
+    msg = StandardReceive(
         address='4d5e6f', target='010b00',
         commandtuple={'cmd1': 0x01, 'cmd2': 0x00},
         flags=MESSAGE_FLAG_BROADCAST_0X80)
     plm.data_received(msg.bytes)
-    yield from asyncio.sleep(.1)
+    yield from asyncio.sleep(RECV_MSG_WAIT)
     for addr in plm.devices:
-        log.info('Device: %s', addr)
+        _LOGGER.info('Device: %s', addr)
 
-    log.info('Replying with Device Status Record')
-    log.info('__________________________________')
-    plm.devices['4d5e6f'].states[0x01].async_refresh_state()
-    yield from asyncio.sleep(.1)
-    msg = insteonplm.messages.standardSend.StandardSend(
-        address='4d5e6f', commandtuple={'cmd1': 0x19, 'cmd2': 0x00},
-        flags=0x00, acknak=0x06)
+    _LOGGER.info('Replying with Device Status Record')
+    _LOGGER.info('__________________________________')
+    msg = StandardSend('4d5e6f', COMMAND_LIGHT_STATUS_REQUEST_0X19_0X00)
+    cmd_sent = yield from wait_for_plm_command(plm, msg, loop)
+    if not cmd_sent:
+        assert False
+    msg = StandardSend('4d5e6f', COMMAND_LIGHT_STATUS_REQUEST_0X19_0X00,
+                       acknak=MESSAGE_ACK)
     plm.data_received(msg.bytes)
-    yield from asyncio.sleep(.1)
+    yield from asyncio.sleep(RECV_MSG_WAIT)
+
     msg = insteonplm.messages.standardReceive.StandardReceive(
         address='4d5e6f', target='1a2b3c',
-        commandtuple={'cmd1': 0x17, 'cmd2': 0xff},
+        commandtuple={'cmd1': 0x17, 'cmd2': 0xaa},
         flags=0x20)
     plm.data_received(msg.bytes)
-    yield from asyncio.sleep(.1)
+    yield from asyncio.sleep(RECV_MSG_WAIT)
 
-    assert plm.devices['4d5e6f'].states[0x01].value == 0xff
+    assert plm.devices['4d5e6f'].states[0x01].value == 0xaa
 
-    # Too much backlog of messages at this point to be clear on
-    # what message will be
-    # returned.
+    _LOGGER.info('Testing device message ACK/NAK handling')
+    _LOGGER.info('_______________________________________')
+    plm.devices['4d5e6f'].states[0x01].on()
+    plm.devices['4d5e6f'].states[0x01].off()
+    plm.devices['4d5e6f'].states[0x01].set_level(0xbb)
 
-    # log.info('Replying with NAK Record')
-    # log.info('__________________________________')
-    # msg = insteonplm.messages.standardSend.StandardSend(
-    #     address='4d5e6f', commandtuple={'cmd1': 0x011,'cmd2': 0xff},
-    #     flags=0x00, acknak=0x15)
-    # plm.data_received(msg.bytes)
-    # yield from asyncio.sleep(3)
-    # assert plm.transport.lastmessage == msg.bytes[:-1]
+    # Test that the first ON command is sent
+    msg = StandardSend('4d5e6f', COMMAND_LIGHT_ON_0X11_NONE, cmd2=0xff)
+    cmd_sent = yield from wait_for_plm_command(plm, msg, loop)
+    if not cmd_sent:
+        assert False
+
+    # ACK the ON command
+    msg = StandardSend('4d5e6f', COMMAND_LIGHT_ON_0X11_NONE,
+                       cmd2=0xff, flags=0x00, acknak=MESSAGE_ACK)
+    plm.data_received(msg.bytes)
+
+    # Let the Direct ACK timeout expire
+    yield from asyncio.sleep(DIRECT_ACK_WAIT_TIMEOUT)
+
+    # Test that the Off command has now sent
+    msg = StandardSend('4d5e6f', COMMAND_LIGHT_OFF_0X13_0X00)
+    cmd_sent = yield from wait_for_plm_command(plm, msg, loop)
+    if not cmd_sent:
+        assert False
+
+    # NAK the OFF command and test that the OFF command is resent
+    plm.transport.lastmessage = ''
+    msg = StandardSend('4d5e6f', COMMAND_LIGHT_OFF_0X13_0X00,
+                       acknak=MESSAGE_NAK)
+    plm.data_received(msg.bytes)
+
+    msg = StandardSend('4d5e6f', COMMAND_LIGHT_OFF_0X13_0X00)
+    cmd_sent = yield from wait_for_plm_command(plm, msg, loop)
+    if not cmd_sent:
+        assert False
+
+    # Let the ACK/NAK timeout expire and test that the OFF command is resent
+    plm.transport.lastmessage = ''
+    msg = StandardSend('4d5e6f', COMMAND_LIGHT_OFF_0X13_0X00)
+    cmd_sent = yield from wait_for_plm_command(plm, msg, loop)
+    if not cmd_sent:
+        assert False
+
+    # ACK the OFF command and let the Direct ACK message expire
+    msg = StandardSend('4d5e6f', COMMAND_LIGHT_OFF_0X13_0X00,
+                       acknak=MESSAGE_ACK)
+    plm.data_received(msg.bytes)
+
+    # Test that the second SET_LEVEL command is sent
+    msg = StandardSend('4d5e6f', COMMAND_LIGHT_ON_0X11_NONE, cmd2=0xbb)
+    cmd_sent = yield from wait_for_plm_command(plm, msg, loop)
+    if not cmd_sent:
+        assert False
 
 
 def test_plm():
     """Main test for the PLM."""
-    devicelist = (
-        {
-            "address": "3c4fc5",
-            "cat": 0x01,
-            "subcat": 0x0b,
-            "product_key": 0x000050
-        },
-        {
-            "address": "43af9b",
-            "cat": 0x02,
-            "subcat": 0x1a,
-            "product_key": 0x00
-        }
-    )
-
-    log = logging.getLogger(__name__)
     logging.basicConfig(level=logging.DEBUG)
     loop = asyncio.get_event_loop()
-    loop.run_until_complete(do_plm(loop, log, devicelist))
+    loop.run_until_complete(do_plm(loop))

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ setenv =
 whitelist_externals = /usr/bin/env
 install_command = /usr/bin/env pip install {opts} {packages}
 commands =
-     py.test --timeout=9 --duration=10 --cov --cov-report= {posargs}
+     py.test --timeout=15 --duration=16 --cov --cov-report= {posargs}
 deps =
      -r{toxinidir}/requirements_test.txt
 

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ setenv =
 whitelist_externals = /usr/bin/env
 install_command = /usr/bin/env pip install {opts} {packages}
 commands =
-     py.test --timeout=15 --duration=16 --cov --cov-report= {posargs}
+     py.test --timeout=30 --duration=31 --cov --cov-report= {posargs}
 deps =
      -r{toxinidir}/requirements_test.txt
 


### PR DESCRIPTION
In a rare issue where the PLM does not return an ACK/NAK message and a direct ACK is expected, the device can hang were no other messages can be sent to the PLM for that device. This change adds a timeout waiting for the ACK/NAK response from the PLM. If it is not received, the message is resent to the PLM.