### PR TITLE
First steps towards Python 3.7 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,12 @@ matrix:
       env: TOXENV=pydocstyle
     - python: 3.6
       env: TOXENV=py36
+    - python: 3.7
+      env: TOXENV=py37
+      dist: xenial
+      sudo: required
+  allow_failures:
+    - python: 3.7
 
 cache:
   directories:

--- a/insteonplm/__init__.py
+++ b/insteonplm/__init__.py
@@ -21,7 +21,7 @@ _LOGGER = logging.getLogger(__name__)
 try:
     ensure_future = asyncio.ensure_future
 except AttributeError:
-    ensure_future = asyncio.async
+    ensure_future = getattr(asyncio, 'async')
 
 
 @asyncio.coroutine

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35, py36, pylint, flake8, pydocstyle
+envlist = py35, py36, py37, pylint, flake8, pydocstyle
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
Start testing with it (allowing failures for now), and fix the lowest hanging issue. There are more things to fix, highlighted by the test failures, but it's a start that I think could be merged as is already in this form.

The sudo: required is (transitional, I believe) weirdness that is/was required for Travis Python 3.7 at least some time ago.