### PR TITLE
Fix labels for keypad in 6 button mode.  Set primary to Main

### DIFF
--- a/insteonplm/devices/dimmableLightingControl.py
+++ b/insteonplm/devices/dimmableLightingControl.py
@@ -89,7 +89,7 @@ class DimmableLightingControl_2334_222(Device):
             self._message_callbacks, 0x00, self._plm.loop)
 
         self._stateList[0x01] = DimmableKeypadA(
-            self._address, "keypadButtonA", 0x01, self._send_msg,
+            self._address, "keypadButtonMain", 0x01, self._send_msg,
             self._message_callbacks, 0x00, self._leds)
 
     def _add_buttons(self, button_list):
@@ -125,5 +125,5 @@ class DimmableLightingControl_2334_222_6(DimmableLightingControl_2334_222):
         super().__init__(plm, address, cat, subcat, product_key,
                          description, model)
 
-        button_list = {3: 'C', 4: 'D', 5: 'E', 6: 'F', 7: 'G'}
+        button_list = {3: 'A', 4: 'B', 5: 'C', 6: 'D'}
         self._add_buttons(button_list)

--- a/insteonplm/devices/switchedLightingControl.py
+++ b/insteonplm/devices/switchedLightingControl.py
@@ -83,7 +83,7 @@ class SwichedLightingControlKeypad(Device):
             self._message_callbacks, 0x00, self._plm.loop)
 
         self._stateList[0x01] = OnOffKeypadA(
-            self._address, "keypadButtonA", 0x01, self._send_msg,
+            self._address, "keypadButtonMain", 0x01, self._send_msg,
             self._message_callbacks, 0x00, self._leds)
 
     def _add_buttons(self, button_list):
@@ -119,5 +119,5 @@ class SwitchedLightingControl_2334_222_6(SwichedLightingControlKeypad):
         super().__init__(plm, address, cat, subcat, product_key,
                          description, model)
 
-        button_list = {3: 'C', 4: 'D', 5: 'E', 6: 'F', 7: 'G'}
+        button_list = {3: 'A', 4: 'B', 5: 'C', 6: 'D'}
         self._add_buttons(button_list)


### PR DESCRIPTION
This is a fix for #111 that changes the button ids for the 6 button keypad to match the descriptions used by Insteon. It changes the keypadButtonA to keypadButtonMain for the 8 button keypad as well.