### PR TITLE
Fix path to readme file in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 license      = Apache License 2.0
-license_file = LICENSE.md
+license_file = LICENSE
 platforms    = any
 description  = Open-source Insteon library running on Python 3.
 long_description = file: README.rst


### PR DESCRIPTION
- The path to the readme file was wrong in setup.cfg. Now it's correct. Confirmed bug when installing on master branch, and confirmed fix when installing PR branch.

fixes #118 