### PR TITLE
Ensure interactive output goes to stdout

### DIFF
--- a/insteonplm/tools.py
+++ b/insteonplm/tools.py
@@ -72,7 +72,9 @@ class Tools():
         if self.logfile:
             logging.basicConfig(level=self.loglevel, filename=self.logfile)
         else:
-            _LOGGING.info('Settig log level to %s', self.loglevel)
+            handler = logging.StreamHandler(sys.stdout)
+            _LOGGING.addHandler(handler)
+            _LOGGING.info('Setting log level to %s', self.loglevel)
             _LOGGING.setLevel(self.loglevel)
             _INSTEONPLM_LOGGING.setLevel(self.loglevel)
 


### PR DESCRIPTION
The interactive tool can be useful for debugging one's system, but currently much of the useful output goes to the _LOGGING logger.  This means that currently things like "help on_off_test" do not show anything on stdout.

This change adds sys.stdout to the logger, so that the interactive tool's output can be, well, interacted with.
